### PR TITLE
Add opt-in debug logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-serverless-helpers",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "node-serverless-helpers", "version": "3.0.3",
+  "name": "node-serverless-helpers",
+  "version": "3.0.3",
   "description": "Helpers to simplify nodejs code on FASS environments",
   "author": "Thomas Ruiz <contact@thomasruiz.eu>",
   "license": "ISC",

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,10 @@ The important part is the `handle` function that does 3 things.
   event comes from, and add useful middlewares to it.
  3. Run your function, and wrap the result to the expected format.
 
+## Debug
+
+To print useful debug logs `export NODE_SLS_HELPERS_DEBUG=*`.
+
 ## TODO
 
  - Global logging system

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { all as merge } from 'deepmerge';
+import {log} from './debug';
 
 export interface ApiConfigCorsOptions {
   origin: string;
@@ -26,7 +27,9 @@ let internalConfig: ConfigOptions = {
 };
 
 export const config = (options: ConfigOptions): void => {
+  log.debug('[CONFIG] Updating config with', options);
   internalConfig = merge([internalConfig, options]) as ConfigOptions;
+  log.debug('[CONFIG] Used config', internalConfig);
 };
 
 export const getConfig = (): ConfigOptions => internalConfig;

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,7 @@
+export const log = {
+  debug: (msg: any, ...args: any[]) => {
+    if (process.env.NODE_SLS_HELPERS_DEBUG) {
+      console.debug('[SLS_HELPERS]', msg, ...args);
+    }
+  }
+};

--- a/src/handling/index.ts
+++ b/src/handling/index.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyHandler, Callback, Context, Handler } from 'aws-lambda';
 
 import { runInitializers } from '../init';
 import { apiHandler, ApiHandler } from './api';
+import {log} from '../debug';
 
 let initPromise: Promise<any>;
 let callInit = true;
@@ -13,14 +14,17 @@ const isApi = (event: any): false | ((next: ApiHandler) => APIGatewayProxyHandle
 export type DefaultHandler = (event: any, context: any) => Promise<any>;
 
 export const handle = (next: ApiHandler | DefaultHandler, shouldThrowOnUnhandled = true): Handler => {
+  log.debug('[HANDLE] Handling event with function', next.name);
   if (callInit) {
+    log.debug('[HANDLE] Calling initializers');
     callInit = false;
     initPromise = runInitializers();
   }
 
   return async (event: any, context: Context, callback: Callback): Promise<any> => {
     await initPromise;
-
+    log.debug('[HANDLE] Initializers ran successfully');
+    log.debug('[HANDLE] Is API Gateway handler', event.pathParameters !== undefined);
     for (const check of [isApi]) {
       const result = check(event);
       if (result) {
@@ -29,9 +33,10 @@ export const handle = (next: ApiHandler | DefaultHandler, shouldThrowOnUnhandled
     }
 
     if (!shouldThrowOnUnhandled) {
+      log.debug('[HANDLE] Using default handler');
       return (next as DefaultHandler)(event, context);
     }
-
+    log.debug('[HANDLE] Unhandled event !');
     throwUnhandledEvent();
   };
 };

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,9 +1,13 @@
+import {log} from './debug';
+
 const globalInitializers: Function[] = [];
 
 export const runInitializers = async () => {
+  log.debug(`[INIT] Running ${globalInitializers.length} initializer`);
   return Promise.all(globalInitializers.map(initializer => initializer()));
 };
 
 export const init = (initializer: Function) => {
+  log.debug('[INIT] Adding initializer', initializer.name);
   globalInitializers.push(initializer);
 };


### PR DESCRIPTION
I recently had to figure out what's going on in middleware registration flow for debug purposes.

The lack of logs made it hard.

As we don't want output in production, I chose an opt-in system.
To enable logging just `export NODE_SLS_HELPERS_DEBUG=*` 

Here is the output:

```
[SLS_HELPERS] [CONFIG] Updating config with { api: { cors: true, blacklist: [] } }
[SLS_HELPERS] [CONFIG] Used config { api: { blacklist: [], cors: true } }
[Init] Registering middleware
[SLS_HELPERS] [MIDDLEWARE][BEFORE] Registering middleware { type: 'ApiGateway', middleware: [ [AsyncFunction] ] }
[SLS_HELPERS] [MIDDLEWARE][AFTER] Registering middleware { type: '__ALWAYS__', middleware: [ [AsyncFunction] ] }
[SLS_HELPERS] [MIDDLEWARE][ERROR] Registering middleware { type: 'ApiGateway', middleware: [ [AsyncFunction] ] }
[SLS_HELPERS] [HANDLE] Handling event with function 
[SLS_HELPERS] [HANDLE] Initializers ran successfully
[SLS_HELPERS] [HANDLE] Is API Gateway handler true
[SLS_HELPERS] [API] Initializing response
[SLS_HELPERS] [API] Calling before middleware
[SLS_HELPERS] [MIDDLEWARE][BEFORE] Running generic middleware []
[SLS_HELPERS] [MIDDLEWARE][BEFORE] Running API gateway middleware [ [AsyncFunction] ]
[SLS_HELPERS] [API] Run business logic code
[SLS_HELPERS] [API] Error happened ! ExpiredTokenException: The security token included in the request is expired
[SLS_HELPERS] [API] Error name ExpiredTokenException
[SLS_HELPERS] [API] 500 - Generic error
[SLS_HELPERS] [API] Formatting response
[SLS_HELPERS] [API] Setting headers
[SLS_HELPERS] [API] Reading CORS config false
[SLS_HELPERS] [API] Formatted {
  headers: {},
  multiValueHeaders: {},
  statusCode: 400,
  body: '"Internal Server Error"'
}
[SLS_HELPERS] [API] Calling error middleware
[SLS_HELPERS] [MIDDLEWARE][ERROR] Running generic middleware []
[SLS_HELPERS] [MIDDLEWARE][ERROR] Running API gateway middleware [ [AsyncFunction] ]
```
